### PR TITLE
fix a memory leak

### DIFF
--- a/improviz.cabal
+++ b/improviz.cabal
@@ -22,6 +22,7 @@ executable improviz
                      , aeson
                      , bytestring
                      , containers
+                     , deepseq
                      , file-embed
                      , filepath
                      , freetype2

--- a/src/Gfx/Commands.hs
+++ b/src/Gfx/Commands.hs
@@ -223,9 +223,8 @@ pushScope = do
 
 popScope :: GraphicsEngine ()
 popScope = do
-  stack <- use scopeStack
-  let prev = head stack
-  assign scopeStack                   (tail stack)
+  (prev:stack) <- use scopeStack
+  assign scopeStack                   (stack)
   assign (fillStyle . S.value)        (view savedFillStyles prev)
   assign (strokeStyle . S.value)      (view savedStrokeStyles prev)
   assign (textureStyle . S.value)     (view savedTextureStyles prev)

--- a/src/Gfx/Context.hs
+++ b/src/Gfx/Context.hs
@@ -20,6 +20,7 @@ import           Gfx.Engine                     ( GfxEngine
 import           Gfx.PostProcessing             ( AnimationStyle )
 import           Graphics.Rendering.OpenGL      ( BlendingFactor )
 import           Language.Ast                   ( Value )
+import           Control.DeepSeq                ( force )
 
 data GfxContext = GfxContext
   { drawShape         :: String -> Float -> Float -> Float -> IO ()
@@ -103,20 +104,20 @@ wrapNoArg :: TVar GfxEngine -> GraphicsEngine () -> IO ()
 wrapNoArg gfx func = do
   ge    <- readTVarIO gfx
   newGe <- execStateT func ge
-  atomically $ writeTVar gfx newGe
+  atomically $ writeTVar gfx $! force newGe
 
 wrapOneArg :: TVar GfxEngine -> (a -> GraphicsEngine ()) -> a -> IO ()
 wrapOneArg gfx func a = do
   ge    <- readTVarIO gfx
   newGe <- execStateT (func a) ge
-  atomically $ writeTVar gfx newGe
+  atomically $ writeTVar gfx $! force newGe
 
 wrapTwoArg
   :: TVar GfxEngine -> (a -> b -> GraphicsEngine ()) -> a -> b -> IO ()
 wrapTwoArg gfx func a b = do
   ge    <- readTVarIO gfx
   newGe <- execStateT (func a b) ge
-  atomically $ writeTVar gfx newGe
+  atomically $ writeTVar gfx $! force newGe
 
 wrapThreeArg
   :: TVar GfxEngine
@@ -128,7 +129,7 @@ wrapThreeArg
 wrapThreeArg gfx func a b c = do
   ge    <- readTVarIO gfx
   newGe <- execStateT (func a b c) ge
-  atomically $ writeTVar gfx newGe
+  atomically $ writeTVar gfx $! force newGe
 
 wrapFourArg
   :: TVar GfxEngine
@@ -141,4 +142,4 @@ wrapFourArg
 wrapFourArg gfx func a b c d = do
   ge    <- readTVarIO gfx
   newGe <- execStateT (func a b c d) ge
-  atomically $ writeTVar gfx newGe
+  atomically $ writeTVar gfx $! force newGe

--- a/src/Gfx/Geometries.hs
+++ b/src/Gfx/Geometries.hs
@@ -6,6 +6,7 @@ module Gfx.Geometries
   , createAllGeometries
   ) where
 
+import           Control.DeepSeq
 import           Data.Int                       ( Int32 )
 import qualified Data.List                     as L
 import qualified Data.Map.Strict               as M
@@ -59,10 +60,11 @@ data GeometryFace = GeometryFace
   deriving (Show, Eq)
 
 data GeometryBuffers = GeometryBuffers
-  { vao       :: VAO
-  , vertCount :: Int32
+  { vao       :: !VAO
+  , vertCount :: !Int32
   }
   deriving (Show, Eq)
+instance NFData GeometryBuffers where rnf = rwhnf
 
 type Geometries = M.Map String GeometryBuffers
 

--- a/src/Gfx/Types.hs
+++ b/src/Gfx/Types.hs
@@ -2,7 +2,7 @@ module Gfx.Types where
 
 import           Data.Yaml                      ( FromJSON(..) )
 
-data Colour = Colour Float Float Float Float
+data Colour = Colour !Float !Float !Float !Float
   deriving (Eq, Show)
 
 instance FromJSON Colour where

--- a/src/Util/Setting.hs
+++ b/src/Util/Setting.hs
@@ -6,17 +6,19 @@ module Util.Setting
   , resetIfUnused
   ) where
 
+import           Control.DeepSeq
 import           Lens.Simple                    ( Lens
                                                 , lens
                                                 )
 
 data Setting v = Setting
-  { currentValue :: v
-  , defaultValue :: v
-  , useCurrent   :: Bool
-  , setLastFrame :: Bool
+  { currentValue :: !v
+  , defaultValue :: !v
+  , useCurrent   :: !Bool
+  , setLastFrame :: !Bool
   }
   deriving (Eq, Show)
+instance NFData v => NFData (Setting v) where rnf (Setting a b _ _) = rnf (a, b)
 
 create :: k -> Setting k
 create value = Setting { currentValue = value

--- a/src/Util/SettingMap.hs
+++ b/src/Util/SettingMap.hs
@@ -9,6 +9,7 @@ module Util.SettingMap
   , snapshot
   ) where
 
+import           Control.DeepSeq
 import qualified Data.Map.Strict               as M
 
 import           Lens.Simple                    ( Lens'
@@ -20,10 +21,11 @@ import           Lens.Simple                    ( Lens'
                                                 )
 
 data Ord k => SettingMap k v = SettingMap
-  { _valueMap      :: M.Map k v
-  , _defaultValues :: M.Map k v
+  { _valueMap      :: !(M.Map k v)
+  , _defaultValues :: !(M.Map k v)
   }
   deriving (Eq, Show)
+instance (NFData k, NFData v) => NFData (SettingMap k v) where rnf = rwhnf
 
 makeLenses ''SettingMap
 


### PR DESCRIPTION
Memory usage of improviz would increase linearly over
time until crash from memory exhaustion.

deepseq is a bit of a sledgehammer,
probably a more precise intervention is possible.

The key change is the ... $! force newGe
which makes the data in the TVar be stored strictly.

Otherwise (conjecture) the data refers to previous
copies of the data structures, etc, which leaks
space because the whole data structure must be
retained.